### PR TITLE
Fix Place of Interest opening when tapping the marker label

### DIFF
--- a/index.js
+++ b/index.js
@@ -297,6 +297,8 @@ module.exports = function(gMapsApi) {
         me.setStyles();
       })
     ];
+
+    gMapsApi.OverlayView.preventMapHitsFrom(this.labelDiv_);
   };
 
   /**


### PR DESCRIPTION
**What?**

Fix Place of Interest opening when tapping the marker label

**Summary**

Apply `preventMapHitsFrom` for marker label div